### PR TITLE
fix issue with mfa token age is not embedded in assume-role

### DIFF
--- a/main.go
+++ b/main.go
@@ -220,7 +220,10 @@ func forkShell(keyId string, secret string, sessionToken string, expiration time
 		for k, v := range envvars {
 			os.Setenv(k, v)
 		}
-		syscall.Exec(os.Getenv("SHELL"), []string{os.Getenv("SHELL")}, syscall.Environ())
+		err := syscall.Exec(os.Getenv("SHELL"), []string{os.Getenv("SHELL")}, syscall.Environ())
+		if err != nil {
+			_error.Println(err.Error())
+		}
 	} else if thisOS == "windows" {
 		cmd := exec.Command("PowerShell")
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
@jonhadfield This PR fixes the issue https://github.com/jonhadfield/sts/issues/3 whereby the mfa token is not attached to actual session token but only `sts:AssumeRole` API call.

Please let me know if you are okay with the pull request.

Thanks.